### PR TITLE
Configure Mockito as Java agent for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar -Xshare:off</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary
- configure maven-surefire-plugin to launch tests with the Mockito core jar as a java agent
- disable class data sharing during tests to suppress OpenJDK warnings

## Testing
- `mvn test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30aeef6648332a3568502396b5478