### PR TITLE
Fix duplicate GitHub Actions CI runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,13 @@ name: Java CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+
+concurrency:
+  group: java-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -13,6 +19,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -23,8 +31,10 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
-      - name: Build and analyze with Maven
+      - name: Build with Maven
+        run: mvn --batch-mode verify
+      - name: Analyze with SonarQube Cloud
+        if: env.SONAR_TOKEN != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn --batch-mode verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn --batch-mode org.sonarsource.scanner.maven:sonar-maven-plugin:sonar


### PR DESCRIPTION
## Summary

- Restrict Java CI push runs to `master` so PR branches are not built twice by both `push` and `pull_request`
- Add concurrency cancellation for superseded Java CI runs on the same PR or branch
- Separate Maven verification from SonarQube Cloud analysis
- Skip Sonar analysis only when `SONAR_TOKEN` is unavailable

## Root cause

Dependabot PR branches triggered Java CI once for `push` and again for `pull_request`. Those runs also failed because Dependabot did not previously have access to `SONAR_TOKEN`, causing SonarQube Cloud analysis to report `Project not found`.

`SONAR_TOKEN` has now also been registered as a Dependabot secret, and PR #54's Java CI was successfully rerun with Sonar analysis.

## Validation

- `JAVA_HOME="$(/usr/libexec/java_home -v 25)" mvn test` (19 tests passed)
- `git diff --check`
- Re-ran PR #54 Java CI successfully, including SonarQube Cloud analysis
